### PR TITLE
Fix config loading in tests

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -21,9 +21,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Test Server
         run: |
-          sudo add-apt-repository ppa:mc3man/trusty-media --yes
-          sudo apt-get update
-          sudo apt-get install ffmpeg gstreamer0.10-ffmpeg
           yarn install --frozen-lockfile
           yarn test
         env:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -10,6 +10,9 @@ jobs:
         ports:
           - 3306:3306
         env:
+          MYSQL_USER: voicecommons
+          MYSQL_PASSWORD: voicecommons
+          MYSQL_DATABASE: voiceweb
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     runs-on: ubuntu-latest

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -6,7 +6,7 @@ jobs:
   test-server:
     services:
       mysql:
-        image: 5.7
+        image: mysql:5.7
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
     runs-on: ubuntu-latest

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,0 +1,30 @@
+name: Default
+
+on: ['push', 'pull_request']
+
+jobs:
+  test-server:
+    services:
+      mysql:
+        image: 5.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Test Server
+        run: |
+          sudo add-apt-repository ppa:mc3man/trusty-media --yes
+          sudo apt-get update
+          sudo apt-get install ffmpeg gstreamer0.10-ffmpeg
+          yarn install --frozen-lockfile
+          yarn test
+        env:
+          CI: true

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -11,6 +11,7 @@ jobs:
           - 3306
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -7,6 +7,8 @@ jobs:
     services:
       mysql:
         image: mysql:5.7
+        ports:
+          - 3306
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
     runs-on: ubuntu-latest

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -8,7 +8,7 @@ jobs:
       mysql:
         image: mysql:5.7
         ports:
-          - 3306
+          - 3306:3306
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -12,8 +12,6 @@ jobs:
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_ROOT_PASSWORD: ''
-          MYSQL_USER: voicecommons
-          MYSQL_PASSWORD: ''
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     runs-on: ubuntu-latest
     strategy:
@@ -29,5 +27,3 @@ jobs:
         run: |
           yarn install --frozen-lockfile
           yarn test
-        env:
-          CI: true

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -13,7 +13,7 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_ROOT_PASSWORD: ''
           MYSQL_USER: voicecommons
-          MYSQL_PASSWORD: voicecommons
+          MYSQL_PASSWORD: ''
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -11,7 +11,6 @@ jobs:
           - 3306:3306
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_ROOT_PASSWORD: ''
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -10,9 +10,6 @@ jobs:
         ports:
           - 3306:3306
         env:
-          MYSQL_USER: voicecommons
-          MYSQL_PASSWORD: voicecommons
-          MYSQL_DATABASE: voiceweb
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_ROOT_PASSWORD: ''
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -14,6 +14,7 @@ jobs:
           MYSQL_PASSWORD: voicecommons
           MYSQL_DATABASE: voiceweb
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_ROOT_PASSWORD: ''
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -11,6 +11,8 @@ jobs:
           - 3306:3306
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_USER: voicecommons
+          MYSQL_PASSWORD: voicecommons
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -12,11 +12,14 @@ jobs:
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_ROOT_PASSWORD: ''
+          MYSQL_USER: voicecommons
+          MYSQL_PASSWORD: voicecommons
+          MYSQL_DATABASE: voiceweb
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -14,7 +14,6 @@ jobs:
           MYSQL_ROOT_PASSWORD: ''
           MYSQL_USER: voicecommons
           MYSQL_PASSWORD: voicecommons
-          MYSQL_DATABASE: voiceweb
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     runs-on: ubuntu-latest
     strategy:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:10-stretch
 
 ARG MAINTAINER="Alberto del Barrio <alberto@mozilla.com>"
-ARG BRANCH="master"
+ARG BRANCH="main"
 ARG COMMIT="local-build"
 ARG TAG=""
 ARG REPO="local"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prettier": "yarn lint --write",
     "start": "yarn build-common && concurrently -p \"[{name}]\" -n \"CO,BE,FE,MT\" -c \"bgYellow.bold,bgBlue.bold,bgMagenta.bold,bgCyan.bold\" \"cd common && yarn dev\" \"cd server && yarn start\" \"cd web && yarn dev\" \"cd maintenance && yarn dev\"",
     "start:prod": "yarn build-common && node server/js/main.js",
-    "test": "yarn build-common && concurrently --kill-others-on-fail \"cd web && yarn test\" \"cd server && yarn test\""
+    "test": "yarn build-common && concurrently --kill-others-on-fail \"cd web && yarn test\" \"cd server && SERVER_CONFIG_PATH='../config.json' yarn test\""
   },
   "husky": {
     "hooks": {

--- a/server/src/lib/model/db/schema.ts
+++ b/server/src/lib/model/db/schema.ts
@@ -40,9 +40,9 @@ export default class Schema {
     const host = opts.host;
     const database = opts.database;
     await this.mysql.rootTransaction(
-      `GRANT SELECT, INSERT, UPDATE, DELETE
-       ON ${database}.* TO '${username}'@'${host}'
-       IDENTIFIED BY '${password}'; FLUSH PRIVILEGES;`
+      `CREATE USER IF NOT EXISTS '${username}' IDENTIFIED BY '${password}';
+       GRANT SELECT, INSERT, UPDATE, DELETE
+       ON ${database}.* TO '${username}'; FLUSH PRIVILEGES;`
     );
 
     // Have the new user use the database.


### PR DESCRIPTION
I think I've got it fixed - it was a real dumb thing about not being able to find root db user config vars because the `config.json` path was being read from `/server` instead of the root directory. (There's also an older bug about granting implicit user permissions that I fixed.) 

Here's the run on my fork, with the action from your most recent run: https://github.com/phirework/voice-web/runs/1739527036 